### PR TITLE
Add execute permission to /entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,7 @@ RUN wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.as
 RUN echo deb http://download.ceph.com/debian-${CEPH_VERSION}/ trusty main | tee /etc/apt/sources.list.d/ceph-${CEPH_VERSION}.list
 RUN apt-get update && apt-get install -y --force-yes ceph radosgw && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Add and set entrypoint
 ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV KVIATOR_VERSION 0.0.5
 ENV CONFD_VERSION 0.10.0
 
 # Install prerequisites
-RUN apt-get update &&  apt-get install -y wget unzip
+RUN apt-get update &&  apt-get install -y wget unzip uuid-runtime
 
 # Install Ceph
 RUN wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -


### PR DESCRIPTION
Add the line of chmod or docker throws warning like:
``docker: Error response from daemon: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"/entrypoint.sh\\\": permission denied\"\n".''